### PR TITLE
fixing material serialization of itembuilder

### DIFF
--- a/codex-plugin/src/main/java/studio/magemonkey/codex/legacy/item/ItemBuilder.java
+++ b/codex-plugin/src/main/java/studio/magemonkey/codex/legacy/item/ItemBuilder.java
@@ -395,7 +395,7 @@ public class ItemBuilder implements ConfigurationSerializable {
     @Override
     public Map<String, Object> serialize() {
         final SerializationBuilder b = SerializationBuilder.start(7);
-        b.append("material", this.material);
+        b.append("material", this.material.getNamespacedID());
         b.append("amount", this.amount);
         b.append("durability", this.durability);
         b.append("unbreakable", this.unbreakable);


### PR DESCRIPTION
Fixes a bug, where Fusion got weird and unserialized yml content on the material which is used for the ItemBuilder. 